### PR TITLE
impl: Encrypt Passwords in Database

### DIFF
--- a/backend/api/login.controller.js
+++ b/backend/api/login.controller.js
@@ -1,4 +1,5 @@
 import UserAuthenticationDAO from "../dao/userAuthenticationDAO.js"
+import PasswordEncryption from "../passwordEncryption.js"
 
 export default class LoginController {
 
@@ -6,7 +7,7 @@ export default class LoginController {
     static async verifyLogin(req, res, next) {
         try {
             const username = req.body.username
-            const password = req.body.password
+            const password = PasswordEncryption.encryptPassword(req.body.password)
             const userrole = req.body.userrole
             let user
 

--- a/backend/api/signup.controller.js
+++ b/backend/api/signup.controller.js
@@ -1,4 +1,5 @@
 import UserAuthenticationDAO from "../dao/userAuthenticationDAO.js"
+import PasswordEncryption from "../passwordEncryption.js"
 
 export default class SignupController {
 
@@ -33,7 +34,7 @@ export default class SignupController {
     static async Signup(req, res, next) {
         try {
             const username = req.body.username
-            const password = req.body.password
+            const password = PasswordEncryption.encryptPassword(req.body.password)
             const userrole = req.body.userrole
 
             let usernameUnique

--- a/backend/passwordEncryption.js
+++ b/backend/passwordEncryption.js
@@ -1,0 +1,26 @@
+import crypto from "crypto"
+import dotenv from "dotenv"
+
+dotenv.config()
+
+export default class PasswordEncryption {
+    static encryptPassword(password) {
+        var algorithm = process.env.ENCRYPT_ALGORITHM
+        var key = process.env.ENCRYPT_KEY
+
+        var cipher = crypto.createCipher(algorithm, Buffer.from(key))
+        var encryptedPassword = cipher.update(password, 'utf8', 'hex') + cipher.final('hex')
+        
+        return encryptedPassword
+    }
+
+    static decryptPassword(password) {
+        var algorithm = process.env.ENCRYPT_ALGORITHM
+        var key = process.env.ENCRYPT_KEY
+
+        var decipher = crypto.createDecipher(algorithm, Buffer.from(key))
+        var decryptedPassword = decipher.update(password, 'hex', 'utf8') + decipher.final('utf8')
+    
+        return decryptedPassword
+    }
+}


### PR DESCRIPTION
This implements password encryption for user sign up and login. When signing up, the password is encrypted after being passed to the backend, then stored in the database in its encrypted form. When logging in, the password attempt is encrypted and compared to the encrypted password from the database.

This requires the .env file to contain the encryption key and algorithm.

This was previously implemented but was lost in the merge to main.

Issue #44