### PR TITLE
fix: Add Route to Add Product

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -58,7 +58,7 @@ const App = () => {
             <Route exact path="/login" component={LoginScreen} />
             <Route exact path="/register" component={RegisterScreen} /> 
             <Route exact path="/cart" component={CartScreen} />    
-   
+            <Route path="/addproduct/:adminId" component={ProductAddScreen} />
 
 
           </Switch>


### PR DESCRIPTION
The route path to the add product page was previously merged into main, but was deleted in a subsequent merge conflict. This commit returns the route to App.js so that the page can be accessed.

GitHub Issue #51